### PR TITLE
NextGeoss customizations

### DIFF
--- a/ckanext/collections/plugin.py
+++ b/ckanext/collections/plugin.py
@@ -21,9 +21,18 @@ class CollectionsPlugin(plugins.SingletonPlugin):
 		False
 
     def form_to_db_schema(self):
-		schema = ckan_schema.group_form_schema()
+        schema = ckan_schema.group_form_schema()
+        schema.update({
+            'collection_id': [toolkit.get_validator('not_empty'), toolkit.get_converter('convert_to_extras')],
+        })
+        return schema
 
-		return schema
+    def db_to_form_schema(self):
+        schema = ckan_schema.group_form_schema()
+        schema.update({
+            'collection_id': [toolkit.get_converter('convert_from_extras')],
+        })
+        return schema
 
     def group_form(group_type='collection'):
         return 'collection/snippets/collection_form.html'

--- a/ckanext/collections/plugin.py
+++ b/ckanext/collections/plugin.py
@@ -24,6 +24,8 @@ class CollectionsPlugin(plugins.SingletonPlugin):
         schema = ckan_schema.group_form_schema()
         schema.update({
             'collection_id': [toolkit.get_validator('not_empty'), toolkit.get_converter('convert_to_extras')],
+            'description': [toolkit.get_validator('not_empty')],
+            'title': [toolkit.get_validator('not_empty')],
         })
         return schema
 

--- a/ckanext/collections/templates/collection/snippets/collection_form.html
+++ b/ckanext/collections/templates/collection/snippets/collection_form.html
@@ -7,7 +7,7 @@
 
   {% block basic_fields %}
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
-    {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Collection'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
+    {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Collection'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs, is_required=true) }}
 
     {{ form.input('collection_id', label=_('Collection ID'), id='field-collection_id', placeholder=_('Collection ID'), value=data.collection_id, error=errors.collection_id,  classes=['control-full'], is_required=true) }}
 
@@ -18,7 +18,7 @@
 
     {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
 
-    {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my group...'), value=data.description, error=errors.description) }}
+    {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about my group...'), value=data.description, error=errors.description, classes=['control-full'], is_required=true) }}
 
     {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
     {% set is_url = data.image_url and data.image_url.startswith('http') %}

--- a/ckanext/collections/templates/collection/snippets/collection_form.html
+++ b/ckanext/collections/templates/collection/snippets/collection_form.html
@@ -9,6 +9,8 @@
     {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
     {{ form.input('title', label=_('Name'), id='field-name', placeholder=_('My Collection'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
 
+    {{ form.input('collection_id', label=_('Collection ID'), id='field-collection_id', placeholder=_('Collection ID'), value=data.collection_id, error=errors.collection_id,  classes=['control-full'], is_required=true) }}
+
     {%- set prefix = h.url_for(group_type + '_read', id='') -%}
     {%- set domain = h.url_for(group_type + '_read', id='', qualified=true) -%}
     {% set domain = domain|replace("http://", "")|replace("https://", "") %}


### PR DESCRIPTION
This branch adds some custom functionality for NextGeoss collections, mainly:

- a new field called `collection_id` which is mandatory as part of the collection creation form
- makes the collection `title` and `description` mandatory as well

This is not meant to merged into master thought, I opened the PR just to facilitate the review. We can either keep the branch here or create another fork of this plugin where we add these NG specific changes. 