### PR TITLE
Fix removing a dataset collection

### DIFF
--- a/ckanext/collections/templates/collection/snippets/collection_item.html
+++ b/ckanext/collections/templates/collection/snippets/collection_item.html
@@ -40,7 +40,7 @@ Example:
   </a>
   {% endblock %}
   {% if group.user_member %}
-    <input name="collectoin_remove.{{ group.id }}" value="{{ _('Remove') }}" type="submit" class="btn btn-danger btn-sm media-edit" title="{{ _('Remove dataset from this collection') }}"/>
+    <input name="collection_remove.{{ group.id }}" value="{{ _('Remove') }}" type="submit" class="btn btn-danger btn-sm media-edit" title="{{ _('Remove dataset from this collection') }}"/>
   {% endif %}
   {% endblock %}
 </li>


### PR DESCRIPTION
Fixes #3.

There was a little typo in the templates that was causing the `collection_remove` action to be ignored.